### PR TITLE
Update the website for Pacstall integration

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -12,6 +12,20 @@
 
 <hr />
 
+<div id="rhino-v120" markdown="1">
+
+# Pacstall integration - rhino-update & rhino-config v1.2
+
+The Rolling Rhino Remix development team has worked closely with the development team of [Pacstall](https://pacstall.dev) to bring their software onto our distribution. Pacstall is an AUR-inspired package manager for Ubuntu. It brings the experience of the Arch User Repository directly to Ubuntu and Ubuntu-based systems with an ever-growing number of user-maintained packages. 
+
+We have integrated, along with the help of the Pacstall development team, Pacstall directly into our Rhino utilities. Pacstall can now be enabled via `rhino-config` and all Pacstall applications can be updated via `rhino-update`.
+
+`rhino-config` has also recieved some new features, such as the user not being prompted multiple times for configurations that they have already enabled. 
+
+In order to enable Pacstall onto your system please read our [Pacstall documentation](https://rollingrhinoremix.github.io/docs-pacstall).
+
+</div>
+
 <div id="2022-04-19" markdown="1">
 
 # Release 2022.04.19 & What's to come for the future.

--- a/docs-pacstall.md
+++ b/docs-pacstall.md
@@ -1,0 +1,31 @@
+<head>
+  <link rel="shortcut icon" type="image/x-icon" href="https://raw.githubusercontent.com/MrBeeBenson/rrr-site/main/favicon.png" />
+</head>
+
+<div id="navigation">
+
+<a href="https://rollingrhinoremix.github.io">Home</a> | <a href="https://rollingrhinoremix.github.io/download">Download</a> | <a href="https://rollingrhinoremix.github.io/docs">Documentation</a> | <a href="https://rollingrhinoremix.github.io/blog">Blog</a> | <a href="https://rollingrhinoremix.github.io/bugs">Bug Tracker</a> | <a href="https://rollingrhinoremix.github.io#contact">Contact</a>
+
+</div>
+
+# Rolling Rhino Remix - Pacstall Documentation
+
+We have recently integrated [Pacstall](https://pacstall.dev) into Rolling Rhino Remix. Pacstall is a piece of software intended to bring the experience of the "Arch User Repository" to Ubuntu. We have worked closely with the developers with Pacstall to best integrate it into our system. Pacstall has to be manually enabled with [rhino-config](https://rollingrhinoremix.github.io/docs-rhino-config). To enable it please read the [rhino-config documentation](https://rollingrhinoremix.github.io/docs-rhino-config), which will provide the steps necessary to enable Pacstall onto your system. 
+
+You are able to browse the [Pacstall package list](https://pacstall.dev/packages?page=0) to see a list of available packages installable via Pacstall.
+
+**Pacstall Commands:**
+- Pacstall -I [Package Name] - This will install a selected package from Pacstall.
+- Pacstall -R [Package Name] - This will remove an installed package from your system.
+- Pacstall -S [Package Name] - This will search to see if a package exists with that name
+- Pacstall -V - This will tell you which version of the package you have installed
+- Pacstall -H - This will provide you with other help commands for Pacstall.
+
+To upgrade your Pacstall packages, please use `rhino-update`, this will update Pacstall as well as all of the applications you have installed from it. 
+
+<hr />
+
+Made with love from all of our [developers & contributors](https://rollingrhinoremix.github.io/contributors.txt), and a large thank you to Martin Wimpress who's [Rolling Rhino](https://github.com/wimpysworld/rolling-rhino) script has inspired the development of this distribution. We would also like to thank Martin for his permission to use the name "Rolling Rhino Remix".
+
+- Ubuntu and Canonical are registered trademarks of Canonical Ltd. Rolling Rhino Remix is not affiliated with the Ubuntu Project. 
+- Linux is the registered trademark of Linus Torvalds.

--- a/docs-rhino-config.md
+++ b/docs-rhino-config.md
@@ -10,7 +10,7 @@
 
 # Rolling Rhino Remix - rhino-config Documentation
 
-The rhino-config command has been created to extend the capabilities of rhino-update. It is not recommended to use rhino-config unless you are aware of what options you are enabling. When you run rhino-config you will be prompted to choose Yes/No on certain configurations, if you choose "Yes", then the changes will be reflected on your system with your next rhino-update. If you have already enabled a configuration option, then you will not be prompted again for that option.
+The rhino-config command has been created to extend the capabilities of rhino-update. It is not recommended to use rhino-config unless you are aware of what options you are enabling. When you run rhino-config you will be prompted to choose Yes/No on certain configurations, if you choose "Yes", then the changes will be reflected on your system with your next rhino-update. If you have already enabled a configuration option, then you will not be prompted again for that option. Once an option has been enabled you will not see it re-appear in rhino-config.
 
 To run rhino-config just open a terminal and type `rhino-config`, once you have completed configuration please make sure to update your system with `rhino-update`. 
 
@@ -23,6 +23,10 @@ You are able to install the latest Linux kernel with rhino-update, to do this yo
 You will be able to disable snapd from rhino-config, and it will automatically replace it with Flatpaks, and install the Flathub repository as a result of this. By disabling snapd all snapcraft applications will be deleted and snap will be flagged to not be reinstalled via apt. This is due to the fact that some .deb applications, such as Firefox, are defaulting to snaps in 22.04 LTS and onwards.
 
 - Since some applications, such as Firefox are installed as snaps by default, you may find yourself without a browser. To rectify this, you can install the Flatpak version of Firefox with `flatpak install firefox`
+
+## Enabling Pacstall
+
+You are able to enable Pacstall, an AUR-like experience, on your system, to do this you will first need to run `rhino-config` to enable it to install via our update utility. Once you have enabled it you are then able to install it with `rhino-update`. Once it has been enabled we recommend you read our [Pacstall Documentation](https://rollingrhinoremix.github.io/docs-pacstall) to learn how to use the software on your system, and how it integrates with Rolling Rhino Remix.
 
 <hr />
 

--- a/index.md
+++ b/index.md
@@ -26,9 +26,13 @@ I have personally felt like Ubuntu should have always adopted the rolling releas
 
 # What new tools are included in the distribution?
 
-The main tool that we have created is `rhino-update`, it will ensure that system updates are ran smoothly, and extends the capabilities of what apt is able to provide. Since not all updates in the devel repository are bleeding-edge due to it being a development repository for future Ubuntu releases, we will be providing some software in our own repositories, such as the latest Linux Kernel. 
+We have created our home-grown utility called Rhino. Rhino has two commands, `rhino-update` and `rhino-config`. 
 
-We have also created a new tool called `rhino-config`, which extends the capabilities of `rhino-update`, by default our update script will only update your system, but you can use our configuration utility so that the update script is permitted to install the latest Linux kernel or replace snapd. 
+`rhino-update` is our extensible update utility, which will ensure that the system updates are ran smoothly. Due to the fact that our update utility is extensible, you can use `rhino-config` to configure the updates you can recieve. You are able to use `rhino-config` for an ever-increasing list of features, such as enabling the installation and upgrades of the latest Linux kernel, removing and replacing Snapd with Flatpaks and enabling Pacstall onto your system.
+
+[Pacstall](https://pacstall.dev) is an AUR-like package manager for Ubuntu and Ubuntu-based systems, and we have worked closely with the Pacstall developers to integrate their software into our distribution. Pacstall brings the experience of the Arch User Repository directly to Ubuntu and Ubuntu-based systems with an ever-growing number of user-maintained packages. 
+
+To learn more about all of the tools we have included in our distribution, please read our [documentation](https://rollingrhinoremix.github.io/docs).
 
 <hr />
 


### PR DESCRIPTION
Now that Pacstall has been integrated into Rolling Rhino Remix, we have created the necessary documentation for it. The blog page now also reflects the updates done to our Rhino utility as a result of this. The index page now also describes that we have included Pacstall.