### PR TITLE
fix(blog.md): fix issue with latest blog post not utilising markdown

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -12,7 +12,7 @@
 
 <hr />
 
-<div id="joining-oin">
+<div id="joining-oin" markdown="1">
 
 # Ensuring software remains free - Rolling Rhino Remix has joined the Open Inventions Network
 


### PR DESCRIPTION
The latest blog post did not utilise markdown due to the <div> not utilising the `markdown="1"` flag.
