### PR TITLE
Fix incorrect domain name in pacstall docs link

### DIFF
--- a/docs-pacstall/index.html
+++ b/docs-pacstall/index.html
@@ -44,7 +44,7 @@
         <div class="information">
             <div class="content">
                 <h1>Rolling Rhino Remix - Pacstall Documentation</h1>
-                <p>We have recently integrated <a href="https://pacstall.dev">Pacstall</a> into Rolling Rhino Remix. Pacstall is a piece of software intended to bring the experience of the “Arch User Repository” to Ubuntu. We have worked closely with the developers with Pacstall to best integrate it into our system. Pacstall has to be manually enabled with <a href="https://rollingrhino.org/docs-rhino-config">rhino-config</a>. To enable it please read the <a href="https://rollingrhinoremix.org/docs-rhino-config">rhino-config documentation</a>, which will provide the steps necessary to enable Pacstall onto your system.</p>
+                <p>We have recently integrated <a href="https://pacstall.dev">Pacstall</a> into Rolling Rhino Remix. Pacstall is a piece of software intended to bring the experience of the “Arch User Repository” to Ubuntu. We have worked closely with the developers with Pacstall to best integrate it into our system. Pacstall has to be manually enabled with <a href="https://rollingrhino.org/docs-rhino-config">rhino-config</a>. To enable it please read the <a href="https://rollingrhino.org/docs-rhino-config">rhino-config documentation</a>, which will provide the steps necessary to enable Pacstall onto your system.</p>
                 <p>You are able to browse the <a href="https://pacstall.dev/packages?page=0">Pacstall package list</a> to see a list of available packages installable via Pacstall.</p>
                 <p><b>Pacstall Commands:</b></p>
                 <p>


### PR DESCRIPTION
The website currently links to
https://rollingrhinoremix.org/docs-rhino-config, but the rest of the
site resides at https://rollingrhino.org/.